### PR TITLE
Only output total times

### DIFF
--- a/RootConstantPerformance/Common/DeviceResources.cpp
+++ b/RootConstantPerformance/Common/DeviceResources.cpp
@@ -586,6 +586,8 @@ void DX::DeviceResources::GetHardwareAdapter(IDXGIAdapter1** ppAdapter)
 		// actual device yet.
 		if (SUCCEEDED(D3D12CreateDevice(adapter.Get(), D3D_FEATURE_LEVEL_11_0, _uuidof(ID3D12Device), nullptr)))
 		{
+			OutputDebugStringW(desc.Description);
+			OutputDebugStringW(L"\n");
 			break;
 		}
 	}

--- a/RootConstantPerformance/Content/Sample3DSceneRenderer.h
+++ b/RootConstantPerformance/Content/Sample3DSceneRenderer.h
@@ -30,6 +30,7 @@ namespace RootConstantPerformance
 	private:
 		// Constant buffers must be 256-byte aligned.
 		static const UINT c_alignedConstantBufferSize = (sizeof(ModelViewProjectionConstantBuffer) + 255) & ~255;
+		static const UINT c_totalFrames = 10 * 60;
 
 		// Cached pointer to device resources.
 		std::shared_ptr<DX::DeviceResources> m_deviceResources;
@@ -63,8 +64,11 @@ namespace RootConstantPerformance
 		float	m_angle;
 		bool	m_tracking;
 		UINT	m_renderCount{ 0 };
-		float	m_greyValue{ 0 };
+		float	m_color[4] = {};
 		UINT	m_drawCount{ 1000 };
+		UINT	m_instanceCount{ 1 };
+		LARGE_INTEGER cpuRootConstantTotal = { 0 };
+		LARGE_INTEGER cpuBufferConstantTotal = { 0 };
 	};
 }
 

--- a/RootConstantPerformance/Content/SamplePixelShader.hlsl
+++ b/RootConstantPerformance/Content/SamplePixelShader.hlsl
@@ -13,16 +13,5 @@ cbuffer Constants : register(b0, space0)
 // A pass-through function for the (interpolated) color data.
 float4 main() : SV_TARGET
 {
-	float result = 0;
-	for (int i = 0; i < 1000; ++i) {
-		result += i0;
-		result += i1;
-		result += i2;
-		result += i3;
-		result += i4;
-		result += i5;
-		result += i6;
-		result += i7;
-	}
-	return float4(result, result, result, 1.0f);
+	return float4(i0 + i1, i2 + i3, i4 + i5, i6 + i7 + 1.0f);
 }


### PR DESCRIPTION
Fixes #1

The PR has a number of fixes:
  1. use less CPU performance queries
  2. only output the total CPU/GPU times
  3. change pixel shader to not do a 1000-iteration loop and make it colorful
  4. number of minor improvements, including printing the adapter description

On Radeon RX460, I'm getting the following results:
```
CPU Root Constants: 0.135872 ms
CPU Buffer Constants: 0.107737 ms
GPU Root Constants: 0.0499731 ms
GPU Buffer Constants: 0.0494161 ms
```